### PR TITLE
Solidify imbusy blocking pms, tpas, etc.

### DIFF
--- a/friends.py
+++ b/friends.py
@@ -5,6 +5,10 @@ friends           = open_json_file("friends", {}) # {Player_UUID:[List_of_friend
 friend_join_sound = "random.orb"
 
 
+def is_friend_of(player, other):
+    lst = friends.get(uid(player))
+    return lst is not None and uid(other) in lst
+
 
 @hook.event("player.PlayerJoinEvent", "high") # creates sound and sends a bold message on friend join
 def fjm(event): # friend join message

--- a/imbusy.py
+++ b/imbusy.py
@@ -144,6 +144,7 @@ class CommandWrapper(Command):
         self.checker = checker
 
     def execute(self, sender, label, args):
+        info("/" + self.getLabel() + " executed by " + sender.getName())
         try:
             if self.checker(sender, args):
                 return self.wrapped.execute(sender, label, args)
@@ -184,39 +185,40 @@ def on_player_command_preprocess(event):
 def replace_ess_commands():
 
     try:
-        mapField = server.getPluginManager().getClass().getDeclaredField("commandMap")
-        mapField.setAccessible(True)
-        commandMap = mapField.get(server.getPluginManager())
+        info("[imbusy] Wrapping ess commands")
+        map_field = server.getPluginManager().getClass().getDeclaredField("commandMap")
+        map_field.setAccessible(True)
+        command_map = map_field.get(server.getPluginManager())
 
-        commandsField = commandMap.getClass().getDeclaredField("knownCommands")
-        commandsField.setAccessible(True)
-        map = commandsField.get(commandMap)
+        commands_field = command_map.getClass().getDeclaredField("knownCommands")
+        commands_field.setAccessible(True)
+        map = commands_field.get(command_map)
 
-        essMsgCmd = map.get("essentials:msg")
-        essReplyCmd = map.get("essentials:reply")
-        essTpaCmd = map.get("essentials:tpa")
-        essTpahereCmd = map.get("essentials:tpahere")
+        ess_msg_cmd = map.get("essentials:msg")
+        ess_reply_cmd = map.get("essentials:reply")
+        ess_tpa_cmd = map.get("essentials:tpa")
+        ess_tpahere_cmd = map.get("essentials:tpahere")
 
-        msgCmdWrapper = CommandWrapper(essMsgCmd, msg_command_checker)
-        replyCmdWrapper = CommandWrapper(essReplyCmd, reply_command_checker)
-        tpaCmdWrapper = CommandWrapper(essTpaCmd, tpa_command_checker)
-        tpahereCmdWrapper = CommandWrapper(essTpahereCmd, tpahere_command_checker)
+        msg_cmd_wrapper = CommandWrapper(ess_msg_cmd, msg_command_checker)
+        reply_cmd_wrapper = CommandWrapper(ess_reply_cmd, reply_command_checker)
+        tpa_cmd_wrapper = CommandWrapper(ess_tpa_cmd, tpa_command_checker)
+        tpahere_cmd_wrapper = CommandWrapper(ess_tpahere_cmd, tpahere_command_checker)
 
         iterator = map.entrySet().iterator()
         while iterator.hasNext():
             entry = iterator.next()
             value = entry.getValue()
-            if value is essMsgCmd:
-                entry.setValue(msgCmdWrapper)
+            if value is ess_msg_cmd:
+                entry.setValue(msg_cmd_wrapper)
                 info("[imbusy] wrapped /" + entry.getKey())
-            elif value is essReplyCmd:
-                entry.setValue(replyCmdWrapper)
+            elif value is ess_reply_cmd:
+                entry.setValue(reply_cmd_wrapper)
                 info("[imbusy] wrapped /" + entry.getKey())
-            elif value is essTpaCmd:
-                entry.setValue(tpaCmdWrapper)
+            elif value is ess_tpa_cmd:
+                entry.setValue(tpa_cmd_wrapper)
                 info("[imbusy] wrapped /" + entry.getKey())
-            elif value is essTpahereCmd:
-                entry.setValue(tpahereCmdWrapper)
+            elif value is ess_tpahere_cmd:
+                entry.setValue(tpahere_cmd_wrapper)
                 info("[imbusy] wrapped /" + entry.getKey())
 
     except:

--- a/imbusy.py
+++ b/imbusy.py
@@ -154,6 +154,7 @@ class CommandWrapper(Command):
     def tabComplete(self, sender, alias, args):
         return self.wrapped.tabComplete(sender, alias, args)
 
+
 def msg_command_checker(sender, args):
     return len(args) <= 1 or whisper(sender, args[0])
 
@@ -171,6 +172,15 @@ def tpa_command_checker(sender, args):
 
 def tpahere_command_checker(sender, args):
     return tpa_command_checker(sender, args)
+
+def mail_command_checker(sender, args):
+    if len(args) < 3 or args[0].lower() != "send":
+        return True
+    target = server.getPlayer(args[1])
+    if target is not None and target is not sender and not sender.hasPermission(override_perm) and target.getName() in busy_players:
+        msg(sender, "&c[&fBUSY&c] %s&r is busy!" % target.getDisplayName())
+        return False
+    return True
 
 
 @hook.event("player.PlayerCommandPreprocessEvent", "monitor")
@@ -196,11 +206,13 @@ def replace_ess_commands():
         ess_reply_cmd = map.get("essentials:reply")
         ess_tpa_cmd = map.get("essentials:tpa")
         ess_tpahere_cmd = map.get("essentials:tpahere")
+        ess_mail_cmd = map.get("essentials:mail")
 
         msg_cmd_wrapper = CommandWrapper(ess_msg_cmd, msg_command_checker)
         reply_cmd_wrapper = CommandWrapper(ess_reply_cmd, reply_command_checker)
         tpa_cmd_wrapper = CommandWrapper(ess_tpa_cmd, tpa_command_checker)
         tpahere_cmd_wrapper = CommandWrapper(ess_tpahere_cmd, tpahere_command_checker)
+        mail_cmd_wrapper = CommandWrapper(ess_mail_cmd, mail_command_checker)
 
         iterator = map.entrySet().iterator()
         while iterator.hasNext():
@@ -217,6 +229,9 @@ def replace_ess_commands():
                 info("[imbusy] wrapped /" + entry.getKey())
             elif value is ess_tpahere_cmd:
                 entry.setValue(tpahere_cmd_wrapper)
+                info("[imbusy] wrapped /" + entry.getKey())
+            elif value is ess_mail_cmd:
+                entry.setValue(mail_cmd_wrapper)
                 info("[imbusy] wrapped /" + entry.getKey())
 
     except:

--- a/imbusy.py
+++ b/imbusy.py
@@ -13,7 +13,9 @@
 
 from helpers import *
 from basecommands import simplecommand
+import org.bukkit.command.Command as Command
 from traceback import format_exc as trace
+
 busy_players = []
 
 
@@ -85,19 +87,138 @@ def on_busy_command(sender, cmd, label, args):
     return True
 
 
-@hook.event("player.PlayerCommandPreprocessEvent", "monitor")
-def on_cmd_preprocess_event(event):
-    message = event.getMessage().split(" ")
-    if message[0] == "/msg" or message[0] == "/w" or message[0] == "/m" or \
-        message[0] == "/tell" or message[0] == "/tpa" or message[0] == "/tpahere":
-        if message[1] in busy_players:
-            plugin_header(recipient = event.getPlayer(), name = "I'M BUSY!")
-            msg(event.getPlayer(), "We are sorry, but %s is currently busy. Please try again later." % message[1])
-            event.setCancelled(True)
-
 @hook.event("player.PlayerQuitEvent", "lowest")
 def on_player_leave(event):
     try:
         busy_players.remove(event.getPlayer().getName())
     except:
         pass
+
+
+#---- Dicode for catching any bothering of busy people ----
+
+
+reply_targets = {}
+override_perm = "utils.imbusy.override"
+
+
+def whisper(sender, target_name):
+    target = server.getPlayer(target_name)
+
+    if target is not None:
+        if target is not sender and not sender.hasPermission(override_perm) and target.getName() in busy_players:
+            msg(sender, "&c[&fBUSY&c] %s&r is busy!" % target.getDisplayName())
+            return False
+
+        reply_targets[sender.getName()] = target.getName()
+
+        # allow the target to reply regardless of sender being busy
+        if target.getName() in reply_targets:
+            del reply_targets[target.getName()]
+    return True
+
+
+def reply(sender):
+    if sender.getName() in reply_targets:
+        target = server.getPlayer(reply_targets[sender.getName()])
+        if target is not None: 
+            if target is not sender and not sender.hasPermission(override_perm) and target.getName() in busy_players:
+                msg(sender, "&c[&fBUSY&c] %s&r is busy!" % target.getDisplayName())
+                return False
+
+            # allow the target to reply regardless of sender being busy
+            if target.getName() in reply_targets:
+                del reply_targets[target.getName()]
+    return True
+
+
+class CommandWrapper(Command):
+
+    def __init__(self, wrapped, checker):
+        Command.__init__(self, wrapped.getName())
+        self.setDescription(wrapped.getDescription())
+        self.setPermission(wrapped.getPermission())
+        self.setUsage(wrapped.getUsage())
+        self.setAliases(wrapped.getAliases())
+        self.wrapped = wrapped
+        self.checker = checker
+
+    def execute(self, sender, label, args):
+        try:
+            if self.checker(sender, args):
+                return self.wrapped.execute(sender, label, args)
+        except:
+            error(trace())
+        return True
+
+    def tabComplete(self, sender, alias, args):
+        return self.wrapped.tabComplete(sender, alias, args)
+
+def msg_command_checker(sender, args):
+    return len(args) <= 1 or whisper(sender, args[0])
+
+def reply_command_checker(sender, args):
+    return len(args) == 0 or reply(sender)
+
+def tpa_command_checker(sender, args):
+    if len(args) == 0:
+        return True
+    target = server.getPlayer(args[0])
+    if target is not None and target is not sender and not sender.hasPermission(override_perm) and target.getName() in busy_players:
+        msg(sender, "&c[&fBUSY&c] %s&r is busy!" % target.getDisplayName())
+        return False
+    return True
+
+def tpahere_command_checker(sender, args):
+    return tpa_command_checker(sender, args)
+
+
+@hook.event("player.PlayerCommandPreprocessEvent", "monitor")
+def on_player_command_preprocess(event):
+    message = event.getMessage().split(" ")
+    if len(message) > 1 and message[0].lower() in ("/tell", "/minecraft:tell") and not whisper(event.getPlayer(), message[1]):
+        event.setCancelled(True)
+
+
+@hook.enable
+def replace_ess_commands():
+
+    try:
+        mapField = server.getPluginManager().getClass().getDeclaredField("commandMap")
+        mapField.setAccessible(True)
+        commandMap = mapField.get(server.getPluginManager())
+
+        commandsField = commandMap.getClass().getDeclaredField("knownCommands")
+        commandsField.setAccessible(True)
+        map = commandsField.get(commandMap)
+
+        essMsgCmd = map.get("essentials:msg")
+        essReplyCmd = map.get("essentials:reply")
+        essTpaCmd = map.get("essentials:tpa")
+        essTpahereCmd = map.get("essentials:tpahere")
+
+        msgCmdWrapper = CommandWrapper(essMsgCmd, msg_command_checker)
+        replyCmdWrapper = CommandWrapper(essReplyCmd, reply_command_checker)
+        tpaCmdWrapper = CommandWrapper(essTpaCmd, tpa_command_checker)
+        tpahereCmdWrapper = CommandWrapper(essTpahereCmd, tpahere_command_checker)
+
+        iterator = map.entrySet().iterator()
+        while iterator.hasNext():
+            entry = iterator.next()
+            value = entry.getValue()
+            if value is essMsgCmd:
+                entry.setValue(msgCmdWrapper)
+                info("[imbusy] wrapped /" + entry.getKey())
+            elif value is essReplyCmd:
+                entry.setValue(replyCmdWrapper)
+                info("[imbusy] wrapped /" + entry.getKey())
+            elif value is essTpaCmd:
+                entry.setValue(tpaCmdWrapper)
+                info("[imbusy] wrapped /" + entry.getKey())
+            elif value is essTpahereCmd:
+                entry.setValue(tpahereCmdWrapper)
+                info("[imbusy] wrapped /" + entry.getKey())
+
+    except:
+        error("[Imbusy] Failed to wrap essentials commands")
+        error(trace())

--- a/imbusy.py
+++ b/imbusy.py
@@ -48,7 +48,7 @@ def on_busy_command(sender, cmd, label, args):
             msg(sender, "Your busy status was removed, you can be bothered again")
         else:
             busy_players.append(sender_name)
-            broadcast(None, "&c[&2Busy&c] %s&r is now busy, don't even TRY bothering them!" % sender.getDisplayName())
+            broadcast(None, "&c[&fBUSY&c] %s&r is now busy, don't even TRY bothering them!" % sender.getDisplayName())
 
     elif len(args) == 1:
         if args[0].lower() == "on":
@@ -56,7 +56,7 @@ def on_busy_command(sender, cmd, label, args):
                 msg(sender, "You cannot be even more focused than this without being a jedi!")
             else:
                 busy_players.append(sender_name)
-                broadcast(None, "&c[&2Busy&c] %s&r is now busy, don't even TRY bothering them!" % sender.getDisplayName())
+                broadcast(None, "&c[&fBUSY&c] %s&r is now busy, don't even TRY bothering them!" % sender.getDisplayName())
 
         elif args[0].lower() == "off":
             try:
@@ -184,6 +184,7 @@ def tpahere_command_checker(sender, args):
     return tpa_command_checker(sender, args)
 
 def mail_command_checker(sender, args):
+    info("Mail command executed")
     if len(args) < 3 or args[0].lower() != "send":
         return True
     target = server.getPlayer(args[1])
@@ -225,24 +226,26 @@ def replace_ess_commands():
         mail_cmd_wrapper = CommandWrapper(ess_mail_cmd, mail_command_checker)
 
         iterator = map.entrySet().iterator()
+        wrapped_commands = []
         while iterator.hasNext():
             entry = iterator.next()
             value = entry.getValue()
+            changed = True
             if value is ess_msg_cmd:
                 entry.setValue(msg_cmd_wrapper)
-                info("[imbusy] wrapped /" + entry.getKey())
             elif value is ess_reply_cmd:
                 entry.setValue(reply_cmd_wrapper)
-                info("[imbusy] wrapped /" + entry.getKey())
             elif value is ess_tpa_cmd:
                 entry.setValue(tpa_cmd_wrapper)
-                info("[imbusy] wrapped /" + entry.getKey())
             elif value is ess_tpahere_cmd:
                 entry.setValue(tpahere_cmd_wrapper)
-                info("[imbusy] wrapped /" + entry.getKey())
             elif value is ess_mail_cmd:
                 entry.setValue(mail_cmd_wrapper)
-                info("[imbusy] wrapped /" + entry.getKey())
+            else:
+                changed = False
+            if changed:
+                wrapped_commands.append(entry.getKey())
+        info("[imbusy] wrapped commands: /" + ", /".join(wrapped_commands))
 
     except:
         error("[Imbusy] Failed to wrap essentials commands")

--- a/imbusy.py
+++ b/imbusy.py
@@ -53,7 +53,7 @@ def on_busy_command(sender, cmd, label, args):
                 msg(sender, "You cannot be even more focused than this without being a jedi!")
             else:
                 busy_players.append(sender.getName())
-                broadcast(None, "&c[&2Busy&c] &fNow busy: %s&r, don't even TRY bothering them!" % sender.getDisplayName())
+                broadcast(None, "&c[&2Busy&c] %s&r is now busy, don't even TRY bothering them!" % sender.getDisplayName())
 
         elif args[0] == "off":
             try:
@@ -144,7 +144,6 @@ class CommandWrapper(Command):
         self.checker = checker
 
     def execute(self, sender, label, args):
-        info("/" + self.getLabel() + " executed by " + sender.getName())
         try:
             if self.checker(sender, args):
                 return self.wrapped.execute(sender, label, args)
@@ -185,7 +184,6 @@ def on_player_command_preprocess(event):
 def replace_ess_commands():
 
     try:
-        info("[imbusy] Wrapping ess commands")
         map_field = server.getPluginManager().getClass().getDeclaredField("commandMap")
         map_field.setAccessible(True)
         command_map = map_field.get(server.getPluginManager())

--- a/imbusy.py
+++ b/imbusy.py
@@ -40,34 +40,44 @@ def on_busy_command(sender, cmd, label, args):
         noperm(sender)
         return True
 
+    sender_name = sender.getName()
+
     if len(args) == 0:
-        msg(sender, "This plugin allows being busy, and when turned on you will not receive any direct messages or tpa requests.")
-        msg(sender, "\nCommands:")
-        msg(sender, "/busy on: turns on busy mode")
-        msg(sender, "/busy off: turns off busy mode")
-        msg(sender, "/busy status [player]: shows your or [player]'s current busy status.")
+        if sender_name in busy_players:
+            busy_players.remove(sender_name)
+            msg(sender, "Your busy status was removed, you can be bothered again")
+        else:
+            busy_players.append(sender_name)
+            broadcast(None, "&c[&2Busy&c] %s&r is now busy, don't even TRY bothering them!" % sender.getDisplayName())
 
     elif len(args) == 1:
-        if args[0] == "on":
-            if sender.getName() in busy_players:
+        if args[0].lower() == "on":
+            if sender_name in busy_players:
                 msg(sender, "You cannot be even more focused than this without being a jedi!")
             else:
-                busy_players.append(sender.getName())
+                busy_players.append(sender_name)
                 broadcast(None, "&c[&2Busy&c] %s&r is now busy, don't even TRY bothering them!" % sender.getDisplayName())
 
-        elif args[0] == "off":
+        elif args[0].lower() == "off":
             try:
-                busy_players.remove(sender.getName())
-                msg(sender, "Master has sent /busy command, %s&r is freeee of bothering!" % sender.getDisplayName())
+                busy_players.remove(sender_name)
+                msg(sender, "Your busy status was removed, you can be bothered again")
             except ValueError:
                 msg(sender, "You are not busy! You cannot be even less busy! Are you perhaps bored?")
 
-        elif args[0] == "status":
-            if sender.getName() in busy_players:
+        elif args[0].lower() == "status":
+            if sender_name in busy_players:
                 msg(sender, "You are super-duper busy and concentrated right now. Think, think, think!")
             else:
                 msg(sender, "You are completely unable to focus right now.")
 
+        elif args[0].lower() in ("?", "help"):
+            msg(sender, "Let's you put yourself in busy status, preventing pms and tpa requests from other players")
+            msg(sender, "\nCommands:")
+            msg(sender, "/busy: toggles busy status")
+            msg(sender, "/busy on: turns on busy status")
+            msg(sender, "/busy off: turns off busy status")
+            msg(sender, "/busy status [player]: shows your or [player]'s current busy status.")
         else:
             unclear(sender)
             return False
@@ -75,7 +85,7 @@ def on_busy_command(sender, cmd, label, args):
     elif len(args) == 2 and args[0] == "status":
         target = server.getPlayer(args[1])
         if target is None:
-            msg(sender, "That player is not online, I doubt they are busy.")
+            msg(sender, "That player is not online, they may be busy IRL, we never know")
         elif target.getName() in busy_players:
             msg(sender, "Yes, %s&r is busy. Shhh..." % target.getDisplayName())
         else:

--- a/main.py
+++ b/main.py
@@ -44,6 +44,8 @@ shared["load_modules"] = [
     "calc",
     # Adds aliasing of chat words
     "chatalias",
+    # For players to point friends
+    "friends",
     # Plugin to locate laggy chunks. /lc <n> lists chunks with more than n entities
     "lagchunks",
     # Adds /report and /rp, Stores reports with time and location


### PR DESCRIPTION
I used reflection to get the Map<String, Command> object from the SimpleCommandMap instance stored in the implementation of PluginManager.
I replaced all Command instances in there that handle /msg, /tpa, /tpahere and /reply, minus /minecraft:tell, with a wrapper that checks if the target is busy.
Tested adequately, but some more would be nice.