### PR TITLE
Added command intercepter tool, used it for //calc

### DIFF
--- a/imbusy.py
+++ b/imbusy.py
@@ -209,110 +209,43 @@ def reply(sender):
             reply_targets[target.getName()] = (sender_name, True)
     return True
 
+try:
 
-class CommandWrapper(Command):
+    def msg_interception(sender, args):
+        return not is_player(sender) or len(args) <= 1 or whisper(sender, args[0])
 
-    def __init__(self, wrapped, checker):
-        Command.__init__(self, wrapped.getName())
-        self.setDescription(wrapped.getDescription())
-        self.setPermission(wrapped.getPermission())
-        self.setUsage(wrapped.getUsage())
-        self.setAliases(wrapped.getAliases())
-        self.wrapped = wrapped
-        self.checker = checker
+    def reply_interception(sender, args):
+        return not is_player(sender) or len(args) == 0 or reply(sender)
 
-    def execute(self, sender, label, args):
-        try:
-            if not is_player(sender) or self.checker(sender, args):
-                return self.wrapped.execute(sender, label, args)
-        except:
-            error(trace())
+    def tpa_interception(sender, args):
+        if len(args) == 0 or not is_player(sender):
+            return True
+        target = server.getPlayer(args[0])
+        if target is not None and not can_send(sender, target):
+            msg(sender, "&c[&fBUSY&c] %s&r is busy!" % target.getDisplayName())
+            return False
         return True
 
-    def tabComplete(self, sender, alias, args):
-        return self.wrapped.tabComplete(sender, alias, args)
+    def tpahere_interception(sender, args):
+        return tpa_command_checker(sender, args)
 
-
-def msg_command_checker(sender, args):
-    return len(args) <= 1 or whisper(sender, args[0])
-
-def reply_command_checker(sender, args):
-    return len(args) == 0 or reply(sender)
-
-def tpa_command_checker(sender, args):
-    if len(args) == 0:
+    def mail_interception(sender, args):
+        if len(args) < 3 or args[0].lower() != "send" or not is_player(sender):
+            return True
+        target = server.getPlayer(args[1])
+        if target is not None and not can_send(sender, target):
+            msg(sender, "&c[&fBUSY&c] %s&r is busy!" % target.getDisplayName())
+            return False
         return True
-    target = server.getPlayer(args[0])
-    if target is not None and not can_send(sender, target):
-        msg(sender, "&c[&fBUSY&c] %s&r is busy!" % target.getDisplayName())
-        return False
-    return True
 
-def tpahere_command_checker(sender, args):
-    return tpa_command_checker(sender, args)
+    register = shared["modules"]["misc"].CommandInterceptions.register
+    register("essentials", "msg", msg_interception)
+    register("minecraft", "tell", msg_interception)
+    register("essentials", "reply", reply_interception)
+    register("essentials", "tpa", tpa_interception)
+    register("essentials", "tpahere", tpahere_interception)
+    register("essentials", "mail", mail_interception)
 
-def mail_command_checker(sender, args):
-    if len(args) < 3 or args[0].lower() != "send":
-        return True
-    target = server.getPlayer(args[1])
-    if target is not None and not can_send(sender, target):
-        msg(sender, "&c[&fBUSY&c] %s&r is busy!" % target.getDisplayName())
-        return False
-    return True
-
-
-@hook.event("player.PlayerCommandPreprocessEvent", "monitor")
-def on_player_command_preprocess(event):
-    message = event.getMessage().split(" ")
-    if len(message) > 1 and message[0].lower() in ("/tell", "/minecraft:tell") and not whisper(event.getPlayer(), message[1]):
-        event.setCancelled(True)
-
-
-def replace_ess_commands():
-
-    try:
-        map_field = server.getPluginManager().getClass().getDeclaredField("commandMap")
-        map_field.setAccessible(True)
-        command_map = map_field.get(server.getPluginManager())
-
-        commands_field = command_map.getClass().getDeclaredField("knownCommands")
-        commands_field.setAccessible(True)
-        map = commands_field.get(command_map)
-
-        ess_msg_cmd = map.get("essentials:msg")
-        ess_reply_cmd = map.get("essentials:reply")
-        ess_tpa_cmd = map.get("essentials:tpa")
-        ess_tpahere_cmd = map.get("essentials:tpahere")
-        ess_mail_cmd = map.get("essentials:mail")
-
-        msg_cmd_wrapper = CommandWrapper(ess_msg_cmd, msg_command_checker)
-        reply_cmd_wrapper = CommandWrapper(ess_reply_cmd, reply_command_checker)
-        tpa_cmd_wrapper = CommandWrapper(ess_tpa_cmd, tpa_command_checker)
-        tpahere_cmd_wrapper = CommandWrapper(ess_tpahere_cmd, tpahere_command_checker)
-        mail_cmd_wrapper = CommandWrapper(ess_mail_cmd, mail_command_checker)
-
-        iterator = map.entrySet().iterator()
-        wrapped_commands = []
-        while iterator.hasNext():
-            entry = iterator.next()
-            value = entry.getValue()
-            changed = True
-            if value is ess_msg_cmd:
-                entry.setValue(msg_cmd_wrapper)
-            elif value is ess_reply_cmd:
-                entry.setValue(reply_cmd_wrapper)
-            elif value is ess_tpa_cmd:
-                entry.setValue(tpa_cmd_wrapper)
-            elif value is ess_tpahere_cmd:
-                entry.setValue(tpahere_cmd_wrapper)
-            elif value is ess_mail_cmd:
-                entry.setValue(mail_cmd_wrapper)
-            else:
-                changed = False
-            if changed:
-                wrapped_commands.append(entry.getKey())
-        info("[imbusy] wrapped commands: /" + ", /".join(wrapped_commands))
-
-    except:
-        error("[Imbusy] Failed to wrap essentials commands")
-        error(trace())
+except:
+    error("[Imbusy] Failed to intercept commands:")
+    error(trace())

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ def on_enable():
     if "blockplacemods" in shared["modules"]:
         shared["modules"]["blockplacemods"].schedule_torch_breaker()
     if "serversigns" in shared["modules"]:
-        shared["modules"]["serversigns"].check_all_signs_and_force_commands()
+        shared["modules"]["serversigns"].check_all_signs()
     info("RedstonerUtils enabled!")
 
 

--- a/main.py
+++ b/main.py
@@ -21,8 +21,6 @@ except:
 def on_enable():
     if "blockplacemods" in shared["modules"]:
         shared["modules"]["blockplacemods"].schedule_torch_breaker()
-    if "imbusy" in shared["modules"]:
-        shared["modules"]["imbusy"].replace_ess_commands()
     if "serversigns" in shared["modules"]:
         shared["modules"]["serversigns"].check_all_signs_and_force_commands()
     info("RedstonerUtils enabled!")

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ def on_enable():
     if "blockplacemods" in shared["modules"]:
         shared["modules"]["blockplacemods"].schedule_torch_breaker()
     if "serversigns" in shared["modules"]:
-        shared["modules"]["serversigns"].check_all_signs()
+        shared["modules"]["serversigns"].check_all_signs_and_intercept_command()
     info("RedstonerUtils enabled!")
 
 

--- a/misc.py
+++ b/misc.py
@@ -55,7 +55,10 @@ class CommandInterceptions:
                 # But without this snippet, the server shuts itself down because 
                 # commands can't be aliases for themselves (shrug) :)
                 aliases = wrapped.getAliases()
-                aliases.remove(wrapped.getLabel())
+                try:
+                    aliases.remove(wrapped.getLabel())
+                except:
+                    pass
                 self.setAliases(aliases)
                 self.wrapped = wrapped
                 self.intercepter = intercepter
@@ -74,19 +77,15 @@ class CommandInterceptions:
 
     @staticmethod
     def add_interception(key, intercepted):
-        try:
-            info("Adding interception for /" + key)
-            registration = CommandInterceptions.registrations[key]
-            tab_completer = registration[1]
-            if tab_completer is None:
-                tab_completer = lambda original_completions, sender, alias, args: original_completions
-            cmd_intercepter = CommandInterceptions.Intercepter(intercepted, registration[0], tab_completer)
-            CommandInterceptions.interceptions[intercepted] = cmd_intercepter
-            for entry in CommandInterceptions.cmd_map.entrySet():
-                if entry.getValue() is intercepted:
-                    entry.setValue(cmd_intercepter)
-        except:
-            error(trace())
+        registration = CommandInterceptions.registrations[key]
+        tab_completer = registration[1]
+        if tab_completer is None:
+            tab_completer = lambda original_completions, sender, alias, args: original_completions
+        cmd_intercepter = CommandInterceptions.Intercepter(intercepted, registration[0], tab_completer)
+        CommandInterceptions.interceptions[intercepted] = cmd_intercepter
+        for entry in CommandInterceptions.cmd_map.entrySet():
+            if entry.getValue() is intercepted:
+                entry.setValue(cmd_intercepter)
 
     @staticmethod
     def init_interceptions():
@@ -103,16 +102,13 @@ class CommandInterceptions:
                 return HashMap.put(self, key, value)
 
             def put(self, key, value):
-                try:
-                    for intercepted in CommandInterceptions.interceptions:
-                        if value is intercepted:
-                            return self.java_put(key, CommandInterceptions.interceptions[intercepted])
-                    ret = self.java_put(key, value)
-                    if key in CommandInterceptions.registrations:
-                        CommandInterceptions.add_interception(key, value)
-                    return ret
-                except:
-                    error(trace())
+                for intercepted in CommandInterceptions.interceptions:
+                    if value is intercepted:
+                        return self.java_put(key, CommandInterceptions.interceptions[intercepted])
+                ret = self.java_put(key, value)
+                if key in CommandInterceptions.registrations:
+                    CommandInterceptions.add_interception(key, value)
+                return ret
 
         try:
             map_field = server.getPluginManager().getClass().getDeclaredField("commandMap")

--- a/misc.py
+++ b/misc.py
@@ -130,7 +130,6 @@ CommandInterceptions.init_interceptions()
 
 
 def worldedit_calc_intercepter(sender, args):
-    info("WorldEdit Calc Intercepter WOOHOO")
     if not sender.hasPermission("worldedit.calc"):
         noperm(sender)
         return False

--- a/plugin.yml
+++ b/plugin.yml
@@ -2,3 +2,6 @@ name: RedstonerUtils
 main: main.py
 version: 3.1.0
 author: redstone_sheep
+
+commands:
+  serversigns:

--- a/plugin.yml
+++ b/plugin.yml
@@ -2,6 +2,3 @@ name: RedstonerUtils
 main: main.py
 version: 3.1.0
 author: redstone_sheep
-
-commands:
-  serversigns:

--- a/serversigns.py
+++ b/serversigns.py
@@ -395,16 +395,16 @@ def can_build2(player, block):
 def check_all_signs_and_intercept_command():
 
     try:
-        CommandInterceptions = shared["modules"]["misc"].CommandInterceptions
-        rsutils_cmd = CommandInterceptions.cmd_map.get("redstonerutils:serversigns")
-        label = rsutils_cmd.getLabel()
+        #CommandInterceptions = shared["modules"]["misc"].CommandInterceptions
+        #rsutils_cmd = CommandInterceptions.cmd_map.get("redstonerutils:serversigns")
+        #label = rsutils_cmd.getLabel()
 
         def interception(sender, args):
-            rsutils_cmd.execute(sender, label, args)
+            svs_command(sender, None, None, args)
             return False
 
         def tab_completion(original, sender, alias, args):
-            return rsutils_cmd.tabComplete(sender, alias, args)
+            return None
 
         shared["modules"]["misc"].CommandInterceptions.register("serversigns", "serversigns", interception, tab_completion)
     except:

--- a/serversigns.py
+++ b/serversigns.py
@@ -392,7 +392,25 @@ def can_build2(player, block):
     return not event.isCancelled()
 
 
-def check_all_signs():
+def check_all_signs_and_intercept_command():
+
+    try:
+        CommandInterceptions = shared["modules"]["misc"].CommandInterceptions
+        rsutils_cmd = CommandInterceptions.cmd_map.get("redstonerutils:serversigns")
+        label = rsutils_cmd.getLabel()
+
+        def interception(sender, args):
+            rsutils_cmd.execute(sender, label, args)
+            return False
+
+        def tab_completion(original, sender, alias, args):
+            return rsutils_cmd.tabComplete(sender, alias, args)
+
+        shared["modules"]["misc"].CommandInterceptions.register("serversigns", "serversigns", interception, tab_completion)
+    except:
+        error("[Serversigns] failed to force commands")
+        error(trace())
+
     """
     Check if all registered signs have an associated sign block in the world. 
     WorldEdit commands could remove them without notification.
@@ -403,20 +421,3 @@ def check_all_signs():
     for loc in signs:
         if server.getWorld(loc[0]).getBlockAt(loc[1], loc[2], loc[3]).getType() not in (Material.WALL_SIGN, Material.SIGN_POST):
             del signs[loc]
-
-try:
-    CommandInterceptions = shared["modules"]["misc"].CommandInterceptions
-    rsutils_cmd = CommandInterceptions.cmd_map.get("redstonerutils:serversigns")
-    label = rsutils_cmd.getLabel()
-
-    def interception(sender, args):
-        rsutils_cmd.execute(sender, label, args)
-        return False
-
-    def tab_completetion(original, sender, alias, args):
-        return rsutils_cmd.tabComplete(sender, alias, args)
-
-    shared["modules"]["misc"].CommandInterceptions.register("serversigns", "serversigns", interception, tab_completion)
-except:
-    error("[Serversigns] failed to force commands")
-    error(trace())


### PR DESCRIPTION
Adds a permission check for `worldedit.calc` to //calc and all its aliases, because currently it does not appear to have a permission check and has the ability to crash the server using a specific set of arguments. Does the same go for //generate btw?
As well as a tool to intercept any command, which should soon replace imbusy implementations of this idea as well as some in another file I don't remember, to misc.py
